### PR TITLE
Fix google account login error

### DIFF
--- a/frontend/web-app/src/types/auth.ts
+++ b/frontend/web-app/src/types/auth.ts
@@ -4,18 +4,18 @@
 
 export interface User {
   id: string
-  tenantId: string
-  googleId?: string
+  tenant_id: string
+  google_id?: string
   email: string
   name: string
-  profileImageUrl?: string
-  phoneNumber?: string
+  profile_image_url?: string
+  phone_number?: string
   address?: string
-  customProfileImageUrl?: string
-  isActive: boolean
-  lastLoginAt?: string
-  createdAt: string
-  updatedAt: string
+  custom_profile_image_url?: string
+  is_active: boolean
+  last_login_at?: string
+  created_at: string
+  updated_at: string
 }
 
 export interface LoginRequest {

--- a/frontend/web-app/src/utils/api.ts
+++ b/frontend/web-app/src/utils/api.ts
@@ -26,8 +26,8 @@ api.interceptors.request.use(
     }
 
     // 테넌트 ID 헤더 추가
-    if (authStore.user?.tenantId) {
-      config.headers['X-Tenant-Id'] = authStore.user.tenantId
+    if (authStore.user?.tenant_id) {
+      config.headers['X-Tenant-Id'] = authStore.user.tenant_id
     }
 
     return config
@@ -87,7 +87,7 @@ export const authApi = {
     return {
       accessToken: d.access_token,
       refreshToken: d.refresh_token,
-      tokenType: d.token_type,
+      tokenType: d.token_type || 'Bearer',
       expiresIn: d.expires_in,
       user: d.user
     }
@@ -107,7 +107,7 @@ export const authApi = {
         auth: {
           accessToken: a.access_token,
           refreshToken: a.refresh_token,
-          tokenType: a.token_type,
+          tokenType: a.token_type || 'Bearer',
           expiresIn: a.expires_in,
           user: a.user
         }
@@ -130,7 +130,7 @@ export const authApi = {
     return {
       accessToken: d.access_token,
       refreshToken: d.refresh_token,
-      tokenType: d.token_type,
+      tokenType: d.token_type || 'Bearer',
       expiresIn: d.expires_in,
       user: d.user
     }
@@ -176,7 +176,7 @@ export const authApi = {
     return {
       accessToken: d.access_token,
       refreshToken: d.refresh_token,
-      tokenType: d.token_type,
+      tokenType: d.token_type || 'Bearer',
       expiresIn: d.expires_in,
       user: d.user
     }


### PR DESCRIPTION
Align frontend `User` type and API response parsing with backend snake_case format and ensure `tokenType` is always present.

The backend `AuthResponse` and `UserInfo` DTOs use snake_case (via `@JsonProperty`), but the frontend `User` interface and API parsing expected camelCase, leading to data mismatch issues during Google login. This PR updates the frontend to correctly handle snake_case properties and provides a default `Bearer` token type if missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4e0a526-26f1-4723-9d80-4ce722772d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4e0a526-26f1-4723-9d80-4ce722772d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

